### PR TITLE
9469 circleci records

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This application notifies a specific Slack channel when a specific Git branch fa
 Slackbot can have multiple notifications set up.
 
 Each notification requires 4 var settings:
-1. REPO_#
-1. GIT_BRANCH_#
-1. SLACK_CHANNEL_#
-1. SLACK_WEBHOOK_URL_#
-
+  1. REPO_#
+  2. GIT_BRANCH_#
+  3. SLACK_CHANNEL_#
+  4. SLACK_WEBHOOK_URL_#
+```
     REPO_1=ui
     GIT_BRANCH_1=master
     SLACK_CHANNEL_1=#eng
@@ -34,7 +34,11 @@ Each notification requires 4 var settings:
     GIT_BRANCH_2=master
     SLACK_CHANNEL_2=#squad-records
     SLACK_WEBHOOK_URL_2=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
+```
+Then, you need to send an env var for the number of alerts:
+```
+    NUM_OF_ALERTS=2
+```
 
 ### Deploying to Heroku
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,24 @@ This application notifies a specific Slack channel when a specific Git branch fa
 1. Run `npm run dev`
 
 ### Sample `.env` file
+Slackbot can have multiple notifications set up.
 
-    SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    SLACK_CHANNEL=#eng
-    GIT_BRANCH=master
+Each notification requires 4 var settings:
+1. REPO_#
+1. GIT_BRANCH_#
+1. SLACK_CHANNEL_#
+1. SLACK_WEBHOOK_URL_#
+
+    REPO_1=ui
+    GIT_BRANCH_1=master
+    SLACK_CHANNEL_1=#eng
+    SLACK_WEBHOOK_URL_1=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+    REPO_2=records
+    GIT_BRANCH_2=master
+    SLACK_CHANNEL_2=#squad-records
+    SLACK_WEBHOOK_URL_2=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
 
 ### Deploying to Heroku
 

--- a/app.coffee
+++ b/app.coffee
@@ -64,13 +64,11 @@ handleCircleciHook = (req, alertNum) ->
   branchEnvVar = (alertNum) ->
     "GIT_BRANCH_#{alertNum}"
   if branch != requireEnv branchEnvVar(alertNum)
-    # return res.send 200, 'Ignored (wrong git branch)'
     return
 
   repoEnvVar = (alertNum) ->
     "REPO_#{alertNum}"
   if reponame != requireEnv repoEnvVar(alertNum)
-    # return res.send 200, 'Ignored (wrong repo)'
     return
 
   slackChannelEnvVar = (alertNum) ->
@@ -81,14 +79,11 @@ handleCircleciHook = (req, alertNum) ->
   if status == 'failed'
     payload.icon_emoji = ':red_circle:'
     payload.text = "@channel #{ branch } build FAILED for #{ reponame }! <#{ build_url }|See details...>"
-    #payload.text = "@channel #{ branch } build FAILED! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
   else if status == 'fixed'
     payload.icon_emoji = ':white_check_mark:'
     payload.text = "@channel #{ branch } build fixed for #{ reponame }. <#{ build_url }|See details...>"
-    #payload.text = "@channel #{ branch } build failed! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
   else
     return
-    # return res.send 200, 'Ignored (only want fixed/failed status)'
 
   slackWebhookEnvVar = (alertNum) ->
     "SLACK_WEBHOOK_URL_#{alertNum}"
@@ -102,7 +97,6 @@ handleCircleciHook = (req, alertNum) ->
         console.log "Slack responded: #{ body }"
   )
   return
-  # res.send 200, "OK, sent #{ JSON.stringify payload }"
 
 http.createServer(app).listen port, ->
   console.log "Server listening on http://localhost:#{ port }"

--- a/app.coffee
+++ b/app.coffee
@@ -50,51 +50,59 @@ app.get '/', (req, res) ->
   res.send 200, 'OK'
 
 maxVal = requireEnv 'NUM_OF_ALERTS'
-alerts = [1..maxVal]
 
-for alertNum in alerts
-  app.post '/', (req, res) ->
-    return res.send 400, 'No payload' unless req.body.payload?
-    {build_url, reponame, branch, status} = req.body.payload
+app.post '/', (req, res) ->
+  return res.send 400, 'No payload' unless req.body.payload?
 
-    branchEnvVar = (alertNum) ->
-      "GIT_BRANCH_#{alertNum}"
-    if branch != requireEnv branchEnvVar(alertNum)
-      return res.send 200, 'Ignored (wrong git branch)'
+  for alertNum in [1..maxVal]
+    do (alertNum) -> handleCircleciHook(req, alertNum)
 
-    repoEnvVar = (alertNum) ->
-      "REPO_#{alertNum}"
-    if reponame != requireEnv repoEnvVar(alertNum)
-      return res.send 200, 'Ignored (wrong repo)'
 
-    slackChannelEnvVar = (alertNum) ->
-      "SLACK_CHANNEL_#{alertNum}"
-    payload =
-      channel: requireEnv slackChannelEnvVar(alertNum)
-      username: 'CircleCI build status'
-    if status == 'failed'
-      payload.icon_emoji = ':red_circle:'
-      payload.text = "@channel #{ branch } build FAILED for #{ reponame }! <#{ build_url }|See details...>"
-      #payload.text = "@channel #{ branch } build FAILED! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
-    else if status == 'fixed'
-      payload.icon_emoji = ':white_check_mark:'
-      payload.text = "@channel #{ branch } build fixed for #{ reponame }. <#{ build_url }|See details...>"
-      #payload.text = "@channel #{ branch } build failed! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
-    else
-      return res.send 200, 'Ignored (only want fixed/failed status)'
+handleCircleciHook = (req, alertNum) ->
+  {build_url, reponame, branch, status} = req.body.payload
 
-    slackWebhookEnvVar = (alertNum) ->
-      "SLACK_WEBHOOK_URL_#{alertNum}"
-    request.post(
-      requireEnv(slackWebhookEnvVar(alertNum)),
-      { form: { payload: JSON.stringify payload } },
-      (err, _, body) ->
-        if err
-          console.error "Slack returned an error: #{ err }"
-        else
-          console.log "Slack responded: #{ body }"
-    )
-    res.send 200, "OK, sent #{ JSON.stringify payload }"
+  branchEnvVar = (alertNum) ->
+    "GIT_BRANCH_#{alertNum}"
+  if branch != requireEnv branchEnvVar(alertNum)
+    # return res.send 200, 'Ignored (wrong git branch)'
+    return
+
+  repoEnvVar = (alertNum) ->
+    "REPO_#{alertNum}"
+  if reponame != requireEnv repoEnvVar(alertNum)
+    # return res.send 200, 'Ignored (wrong repo)'
+    return
+
+  slackChannelEnvVar = (alertNum) ->
+    "SLACK_CHANNEL_#{alertNum}"
+  payload =
+    channel: requireEnv slackChannelEnvVar(alertNum)
+    username: 'CircleCI build status'
+  if status == 'failed'
+    payload.icon_emoji = ':red_circle:'
+    payload.text = "@channel #{ branch } build FAILED for #{ reponame }! <#{ build_url }|See details...>"
+    #payload.text = "@channel #{ branch } build FAILED! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
+  else if status == 'fixed'
+    payload.icon_emoji = ':white_check_mark:'
+    payload.text = "@channel #{ branch } build fixed for #{ reponame }. <#{ build_url }|See details...>"
+    #payload.text = "@channel #{ branch } build failed! <#{ build_url }|See details...>\nhttp://i.imgur.com/TVVFOhS.gif"
+  else
+    return
+    # return res.send 200, 'Ignored (only want fixed/failed status)'
+
+  slackWebhookEnvVar = (alertNum) ->
+    "SLACK_WEBHOOK_URL_#{alertNum}"
+  request.post(
+    requireEnv(slackWebhookEnvVar(alertNum)),
+    { form: { payload: JSON.stringify payload } },
+    (err, _, body) ->
+      if err
+        console.error "Slack returned an error: #{ err }"
+      else
+        console.log "Slack responded: #{ body }"
+  )
+  return
+  # res.send 200, "OK, sent #{ JSON.stringify payload }"
 
 http.createServer(app).listen port, ->
   console.log "Server listening on http://localhost:#{ port }"


### PR DESCRIPTION
### Problem:
- was setup to only enable notifications per 1 git branch, per 1 slack channel, and treating all incoming repos the same.
- Issue https://github.com/lanetix/issues/issues/9469

### Solution:
Now uses 4 env var per notification.
And any notification can be a combo of these 4.

```
REPO_1=ui
GIT_BRANCH_1=master
SLACK_CHANNEL_1=#eng
SLACK_WEBHOOK_URL_1=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

REPO_2=records
GIT_BRANCH_2=master
SLACK_CHANNEL_2=#squad-records    
SLACK_WEBHOOK_URL_2=https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

NUM_OF_ALERTS=2
```