### PR TITLE
res response 200 after all notification settings are checked

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -57,6 +57,8 @@ app.post '/', (req, res) ->
   for alertNum in [1..maxVal]
     do (alertNum) -> handleCircleciHook(req, alertNum)
 
+  return res.send 200, 'All notification settings were checked'
+
 
 handleCircleciHook = (req, alertNum) ->
   {build_url, reponame, branch, status} = req.body.payload


### PR DESCRIPTION
We were getting a `503` returned to circleci.
<img width="787" alt="screen shot 2017-02-21 at 12 00 06 pm" src="https://cloud.githubusercontent.com/assets/10232835/23182418/535c5718-f82d-11e6-88c4-e359c5d4f921.png">



Because `200` was never returned after trying all permutations.
Now fixed.
Tested.
No more warning.
